### PR TITLE
Transform navigation menu to Tailwind CSS

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,15 +1,15 @@
-<header class="site-header" role="banner">
-    <div class="wrapper">
+<header class="site-header w-full" role="banner">
+    <div class="wrapper flex items-center justify-between px-4 md:px-8 py-4 max-w-7xl mx-auto">
         {%- assign default_paths = site.pages | map: "path" -%}
         {%- assign page_paths = site.header_pages | default: default_paths -%}
-        <div class="left-container">
+        <div class="left-container flex items-center gap-4">
             <div class="title-wrapper">
                 <a class="site-title" rel="author" href="{{ "/" | relative_url }}">
                     <span class="text-2xl">{{ site.title | escape }}</span>
                 </a>
             </div>
             <div class="footer-icons">
-                <ul>
+                <ul class="flex gap-2">
                     {% assign dimension = "sm" %}
                     {% include icons.html %}
                 </ul>
@@ -17,29 +17,45 @@
         </div>
 
         {%- if page_paths -%}
-        <nav class="site-nav">
-            <input type="checkbox" id="nav-trigger" class="nav-trigger" />
-            <label for="nav-trigger">
-                <span class="menu-icon">
-                    <svg viewBox="0 0 18 15" width="18px" height="15px">
-                        <path
-                            d="M18,1.484c0,0.82-0.665,1.484-1.484,1.484H1.484C0.665,2.969,0,2.304,0,1.484l0,0C0,0.665,0.665,0,1.484,0 h15.032C17.335,0,18,0.665,18,1.484L18,1.484z M18,7.516C18,8.335,17.335,9,16.516,9H1.484C0.665,9,0,8.335,0,7.516l0,0 c0-0.82,0.665-1.484,1.484-1.484h15.032C17.335,6.031,18,6.696,18,7.516L18,7.516z M18,13.516C18,14.335,17.335,15,16.516,15H1.484 C0.665,15,0,14.335,0,13.516l0,0c0-0.82,0.665-1.483,1.484-1.483h15.032C17.335,12.031,18,12.695,18,13.516L18,13.516z" />
-                    </svg>
-                </span>
-            </label>
-
-            <div class="trigger">
-                <a class="page-link" href="/tips" title="Tips">Tips</a>
+        <nav class="site-nav relative bg-transparent">
+            <!-- Desktop Navigation -->
+            <div class="hidden md:flex items-center gap-6">
+                <a class="page-link text-[var(--nav-color)] hover:text-[var(--hover-color)] transition-colors" href="/tips" title="Tips">Tips</a>
                 {%- for path in page_paths -%}
                 {%- assign my_page = site.pages | where: "path", path | first -%}
                 {% unless my_page.exclude %}
-
                 {%- if my_page.title -%}
-                <a class="page-link" href="{{ my_page.url | relative_url }}"
+                <a class="page-link text-[var(--nav-color)] hover:text-[var(--hover-color)] transition-colors" href="{{ my_page.url | relative_url }}"
                     title="{{ my_page.title | escape }}">{{ my_page.title | escape }}</a>
                 {%- endif -%}
                 {% endunless %}
                 {%- endfor -%}
+            </div>
+
+            <!-- Mobile Navigation -->
+            <div class="md:hidden">
+                <input type="checkbox" id="nav-trigger" class="peer sr-only" />
+                <label for="nav-trigger" style="display: flex !important; float: none !important; align-items: center !important; justify-content: center !important;" class="cursor-pointer p-2 text-[var(--nav-color)] hover:text-[var(--hover-color)] transition-colors bg-transparent border border-[var(--border-color)] rounded-md">
+                    <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 20 20">
+                        <path fill-rule="evenodd" d="M3 5a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zM3 15a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd"/>
+                    </svg>
+                </label>
+
+                <!-- Mobile Dropdown -->
+                <div class="hidden peer-checked:block absolute top-full right-0 z-50 bg-[var(--page-color)] dark:bg-[var(--page-color)] shadow-lg rounded-lg py-2 border border-[var(--border-color)] min-w-[200px] mt-1">
+                    <div class="flex flex-col">
+                        <a class="page-link block px-4 py-3 text-[var(--nav-color)] hover:bg-[var(--nav-hover-color)] transition-colors" href="/tips" title="Tips">Tips</a>
+                        {%- for path in page_paths -%}
+                        {%- assign my_page = site.pages | where: "path", path | first -%}
+                        {% unless my_page.exclude %}
+                        {%- if my_page.title -%}
+                        <a class="page-link block px-4 py-3 text-[var(--nav-color)] hover:bg-[var(--nav-hover-color)] transition-colors" href="{{ my_page.url | relative_url }}"
+                            title="{{ my_page.title | escape }}">{{ my_page.title | escape }}</a>
+                        {%- endif -%}
+                        {% endunless %}
+                        {%- endfor -%}
+                    </div>
+                </div>
             </div>
         </nav>
         {%- endif -%}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,5 +1,5 @@
 <header class="site-header w-full" role="banner">
-    <div class="wrapper flex items-center justify-between px-4 md:px-8 py-4 max-w-7xl mx-auto">
+    <div class="wrapper flex items-center justify-between px-4 md:px-8 py-4">
         {%- assign default_paths = site.pages | map: "path" -%}
         {%- assign page_paths = site.header_pages | default: default_paths -%}
         <div class="left-container flex items-center gap-4">

--- a/_scss/custom.scss
+++ b/_scss/custom.scss
@@ -130,6 +130,11 @@ h1#bio, h1#personal, h1#stack {
 
   .site-nav {
     top: 24px;
+    background-color: transparent !important;
+    border: none !important;
+    position: relative !important;
+    top: auto !important;
+    right: auto !important;
   }
 
   .site-title {


### PR DESCRIPTION
This PR transforms the navigation menu from custom CSS to Tailwind CSS with:

## Changes
- **Desktop**: Horizontal navigation with  (hidden on mobile)
- **Mobile**: CSS-only hamburger menu using  pattern (no JavaScript)
- **Mobile dropdown**: Full border, rounded corners, theme-aware colors
- **Hamburger button**: Centered icon with border, transparent background

## Technical Details
- Uses CSS variables (, ) for theme support
- Mobile menu shows below  breakpoint (768px)
- Overrides minima base CSS with  inline styles for proper centering
- Preserves all existing menu items (Tips, About, Archive, Tags)

## Testing
- [x] Desktop menu visible on md+ screens
- [x] Hamburger visible on mobile only
- [x] Dropdown opens/closes via checkbox hack
- [x] Dark mode support for all elements
- [x] Menu items functional