### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - source
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/diamantidis/diamantidis.github.io/security/code-scanning/1](https://github.com/diamantidis/diamantidis.github.io/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/ci.yml` to enforce least privilege instead of inheriting defaults.  
Best single fix: define workflow-level permissions right after the trigger section so all jobs inherit them. Since this workflow runs Danger on pull requests (which commonly comments on PRs), include:
- `contents: read` (minimum for checkout/read repo content)
- `pull-requests: write` (allows PR comments/updates by Danger)

This preserves intended functionality while restricting token scope.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
