### PR TITLE
Remove automatic Lighthouse CI to save GitHub Actions minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,6 @@ jobs:
           JEKYLL_ENV: production
         run: bundle exec jekyll build
 
-      - name: Run Lighthouse CI
-        run: npm run lighthouse
-
       - name: Install proselint
         run: pip3 install --user proselint==0.14.0
 

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -62,20 +62,3 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v5
-
-  lighthouse:
-    needs: deploy
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Set up tools with mise
-        uses: jdx/mise-action@v2
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Run Lighthouse CI
-        run: npx lhci autorun --config=lighthouserc.live.json

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,8 +1,6 @@
 name: Lighthouse CI
 
 on:
-  schedule:
-    - cron: '0 3 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Plan
Remove automatic Lighthouse CI from CI workflows to save GitHub Actions minutes while keeping Lighthouse as a manual task.

## Changes
- Remove Lighthouse CI from ci.yml (PR checks)
- Remove Lighthouse CI from github-pages.yml (post-deploy)
- Remove cron schedule from lighthouse.yml (now manual-only via workflow_dispatch)

## Tests
- Users can still run Lighthouse smoke tests locally with 
> lighthouse:smoke
> lhci autorun --config=lighthouserc.smoke.json
- Can trigger manually via GitHub Actions UI: Actions → Lighthouse CI → Run workflow

## Benefits
- Saves CI minutes by removing automatic Lighthouse runs from PRs and post-deploy
- Maintains ability to run Lighthouse audits manually via lighthouse.yml
- Users can still run smoke tests locally with 
> lighthouse:smoke
> lhci autorun --config=lighthouserc.smoke.json